### PR TITLE
Add integration tests for chord-mark public API

### DIFF
--- a/packages/chord-mark/tests/integration-public-api/fixtures/songs.js
+++ b/packages/chord-mark/tests/integration-public-api/fixtures/songs.js
@@ -1,0 +1,172 @@
+import song from '../helpers/songInput';
+
+// ============ Basic ============
+
+export const lyricsOnly = () =>
+	song(
+		'When I find myself in times of trouble',
+		'Mother Mary comes to me'
+	);
+
+export const emptyLines = () =>
+	song(
+		'First line',
+		'',
+		'Second line',
+		'',
+		'Third line'
+	);
+
+export const singleChordWithLyrics = () =>
+	song(
+		'C.. G..',
+		'When I find myself in times of trouble'
+	);
+
+export const lyricWithColonPrefix = () =>
+	song(
+		':This is an escaped lyric line'
+	);
+
+export const htmlInInput = () =>
+	song(
+		'<p>Some HTML content</p>',
+		'<b>Bold text</b> and normal'
+	);
+
+// ============ Chords ============
+
+export const singleChord = () => song('C');
+export const multipleChords = () => song('C.. G..');
+export const chordsWithDots = () => song('C... G.');
+export const multipleBars = () => song('C G Am F');
+export const barRepeat = () => song('C.. G.. %');
+export const chordLineRepeat = () =>
+	song(
+		'C.. G..',
+		'First line',
+		'%%',
+		'Second line'
+	);
+
+export const noChord = () => song('C.. NC.. G.. NC..');
+
+export const subBeatGroup = () => song('C.. [Am G]');
+export const multipleSubBeatGroups = () => song('C. [Am G] [F E].');
+
+export const positionedChords = () =>
+	song(
+		'Am. [Am Am/G] FM7. F6.',
+		'_ Mother _Ma_ry _comes to _me'
+	);
+
+// ============ Sections ============
+
+export const allSectionTypes = () =>
+	song('#v', '#c', '#i', '#b', '#o', '#s', '#a', '#p', '#u');
+
+export const sectionWithContent = () =>
+	song(
+		'#v',
+		'C G',
+		'First verse line',
+		'Am F',
+		'Second verse line',
+		'',
+		'#c',
+		'F G',
+		'Chorus line'
+	);
+
+export const sectionCopy = () =>
+	song(
+		'#v',
+		'C G',
+		'verse line',
+		'#v',
+		'#v'
+	);
+
+export const sectionMultiply = () =>
+	song(
+		'#v x2',
+		'C G',
+		'verse line'
+	);
+
+export const customSection = () => song('#special');
+
+// ============ Time Signatures ============
+
+export const timeSignature4_4 = () => song('4/4', 'C.. G..');
+export const timeSignature3_4 = () => song('3/4', 'C. D. E.');
+export const timeSignature6_8 = () => song('6/8', 'Am F G');
+
+export const inlineTimeSignatureChange = () =>
+	song(
+		'4/4',
+		'2/4 G 4/4 Am',
+		'_A line _with changes'
+	);
+
+// ============ Keys ============
+
+export const explicitKey = () =>
+	song(
+		'key G',
+		'C.. G..'
+	);
+
+export const explicitKeyMinor = () =>
+	song(
+		'key Am',
+		'Am.. Dm..'
+	);
+
+export const multipleKeyChanges = () =>
+	song(
+		'key C',
+		'C.. G..',
+		'line 1',
+		'key G',
+		'G.. D..',
+		'line 2'
+	);
+
+export const autoDetectedKey = () => song('F.. Bb..');
+
+// ============ Complex / Full Songs ============
+
+export const fullSong = () =>
+	song(
+		'4/4',
+		'key G',
+		'#v',
+		'C.. G..',
+		'When I find myself in times of trouble',
+		'Am. [Am Am/G] FM7. F6.',
+		'_ Mother _Ma_ry _comes to _me',
+		'%%',
+		'Speaking words of wisdom',
+		'F. [C/E Dm7] C..',
+		'Let it _be _ _ _',
+		'',
+		'#c',
+		'Am.. G..',
+		'Let it be',
+		'',
+		'key Am',
+		'#v'
+	);
+
+// ============ Error Cases ============
+
+export const invalidBeatCount = () => song('C.');
+export const invalidBeatCount5beats = () => song('C..... ');
+export const invalidSubBeatGroupDuration = () => song('A... [B7. D7.]');
+export const invalidSubBeatGroupUnclosed = () => song('A... [B7 D7');
+export const invalidSubBeatGroupNested = () => song('A... [B7 [D7');
+export const invalidSubBeatGroupSingle = () => song('A... [C]');
+export const invalidBarRepeatFirst = () => song('% A');
+export const invalidBarRepeatIncomplete = () => song('A... % A');
+export const invalidChordRepetition = () => song('A. A...');

--- a/packages/chord-mark/tests/integration-public-api/helpers/songInput.js
+++ b/packages/chord-mark/tests/integration-public-api/helpers/songInput.js
@@ -1,0 +1,2 @@
+const song = (...lines) => lines.join('\n');
+export default song;

--- a/packages/chord-mark/tests/integration-public-api/helpers/toText.js
+++ b/packages/chord-mark/tests/integration-public-api/helpers/toText.js
@@ -1,0 +1,11 @@
+import stripTags from '../../../src/core/dom/stripTags';
+
+const toText = (chordMark) => {
+	const allLines = chordMark.match(/(<p.*?>.*?<\/p>)/gm);
+
+	return allLines
+		.map((line) => stripTags(line))
+		.map((line) => (line === '&nbsp;' ? '' : line))
+		.join('\n');
+};
+export default toText;

--- a/packages/chord-mark/tests/integration-public-api/lineTypes.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/lineTypes.spec.js
@@ -1,0 +1,22 @@
+import { lineTypes } from '../../src/chordMark';
+
+describe('lineTypes', () => {
+	test('exports an object', () => {
+		expect(typeof lineTypes).toBe('object');
+	});
+
+	test('has exactly 6 line types', () => {
+		expect(Object.keys(lineTypes)).toHaveLength(6);
+	});
+
+	test.each([
+		['CHORD', 'chord'],
+		['EMPTY_LINE', 'emptyLine'],
+		['KEY_DECLARATION', 'keyDeclaration'],
+		['LYRIC', 'lyric'],
+		['SECTION_LABEL', 'sectionLabel'],
+		['TIME_SIGNATURE', 'timeSignature'],
+	])('has %s = "%s"', (key, value) => {
+		expect(lineTypes[key]).toBe(value);
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/parseSong-basics.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/parseSong-basics.spec.js
@@ -1,0 +1,108 @@
+import { parseSong, lineTypes } from '../../src/chordMark';
+import song from './helpers/songInput';
+import {
+	lyricsOnly,
+	emptyLines,
+	singleChordWithLyrics,
+	lyricWithColonPrefix,
+	htmlInInput,
+} from './fixtures/songs';
+
+describe('parseSong - basics', () => {
+	test('accepts a multiline string as input', () => {
+		const parsed = parseSong(singleChordWithLyrics());
+		expect(parsed).toHaveProperty('allLines');
+		expect(parsed).toHaveProperty('allChords');
+		expect(parsed).toHaveProperty('allKeys');
+	});
+
+	test('accepts an array as input', () => {
+		const input = [
+			'When I find myself in times of trouble',
+			'Mother Mary comes to me',
+		];
+		const parsed = parseSong(input);
+		expect(parsed.allLines).toHaveLength(2);
+		expect(parsed.allLines[0].type).toBe('lyric');
+		expect(parsed.allLines[1].type).toBe('lyric');
+	});
+
+	test('parses lyrics only', () => {
+		const parsed = parseSong(lyricsOnly());
+		expect(parsed.allLines).toHaveLength(2);
+		parsed.allLines.forEach((line) => {
+			expect(line.type).toBe('lyric');
+		});
+		expect(parsed.allLines[0].string).toBe(
+			'When I find myself in times of trouble'
+		);
+		expect(parsed.allLines[0].model.lyrics).toBe(
+			'When I find myself in times of trouble'
+		);
+		expect(parsed.allLines[0].model.chordPositions).toEqual([]);
+	});
+
+	test('parses empty lines', () => {
+		const parsed = parseSong(emptyLines());
+		const emptyLineTypes = parsed.allLines.filter(
+			(l) => l.type === 'emptyLine'
+		);
+		expect(emptyLineTypes.length).toBe(2);
+	});
+
+	test('handles lyric line with : prefix', () => {
+		const parsed = parseSong(lyricWithColonPrefix());
+		expect(parsed.allLines).toHaveLength(1);
+		expect(parsed.allLines[0].type).toBe('lyric');
+		expect(parsed.allLines[0].model.lyrics).toBe(
+			'This is an escaped lyric line'
+		);
+	});
+
+	test('strips HTML from input', () => {
+		const parsed = parseSong(htmlInInput());
+		expect(parsed.allLines).toHaveLength(2);
+		parsed.allLines.forEach((line) => {
+			expect(line.string).not.toContain('<');
+			expect(line.string).not.toContain('>');
+		});
+	});
+
+	test('returns correct allChords for lyrics only', () => {
+		const parsed = parseSong(lyricsOnly());
+		expect(parsed.allChords).toEqual([]);
+	});
+
+	test('returns correct allKeys for no key declaration', () => {
+		const parsed = parseSong(lyricsOnly());
+		expect(parsed.allKeys.explicit).toEqual([]);
+	});
+
+	test('returns allLines with type, string, and model', () => {
+		const parsed = parseSong(song('C', 'A lyric'));
+		parsed.allLines.forEach((line) => {
+			expect(line).toHaveProperty('type');
+			expect(line).toHaveProperty('string');
+			expect(line).toHaveProperty('model');
+		});
+	});
+
+	test('line types match lineTypes enum values', () => {
+		const parsed = parseSong(
+			song('4/4', 'key C', '#v', 'C G', 'A lyric', '')
+		);
+		const types = parsed.allLines.map((l) => l.type);
+		expect(types).toContain(lineTypes.TIME_SIGNATURE);
+		expect(types).toContain(lineTypes.KEY_DECLARATION);
+		expect(types).toContain(lineTypes.SECTION_LABEL);
+		expect(types).toContain(lineTypes.CHORD);
+		expect(types).toContain(lineTypes.LYRIC);
+		expect(types).toContain(lineTypes.EMPTY_LINE);
+	});
+
+	test('empty string input produces empty result', () => {
+		const parsed = parseSong('');
+		expect(parsed.allLines).toHaveLength(1);
+		expect(parsed.allLines[0].type).toBe('emptyLine');
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/parseSong-chords.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/parseSong-chords.spec.js
@@ -48,7 +48,7 @@ describe('parseSong - chords', () => {
 	});
 
 	test('parses chord line repeat (%%)', () => {
-		// %% repeats the 2nd-to-last chord line (% = last, %% = 2nd-to-last)
+		// %% repeats the 2nd-to-last chord line
 		const parsed = parseSong(
 			song('C.. G..', 'First line', 'Am.. F..', 'Second line', '%%')
 		);
@@ -57,6 +57,9 @@ describe('parseSong - chords', () => {
 		expect(chordLines[0].isFromChordLineRepeater).toBeFalsy();
 		expect(chordLines[1].isFromChordLineRepeater).toBeFalsy();
 		expect(chordLines[2].isFromChordLineRepeater).toBe(true);
+		// %% repeats the 1st chord line (C.. G..), not the 2nd (Am.. F..)
+		expect(chordLines[2].model.allBars[0].allChords[0].string).toBe('C..');
+		expect(chordLines[2].model.allBars[0].allChords[1].string).toBe('G..');
 	});
 
 	test('parses no-chord (NC)', () => {

--- a/packages/chord-mark/tests/integration-public-api/parseSong-chords.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/parseSong-chords.spec.js
@@ -4,11 +4,6 @@ import {
 	singleChord,
 	multipleChords,
 	multipleBars,
-	barRepeat,
-	chordLineRepeat,
-	noChord,
-	subBeatGroup,
-	multipleSubBeatGroups,
 	positionedChords,
 } from './fixtures/songs';
 

--- a/packages/chord-mark/tests/integration-public-api/parseSong-chords.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/parseSong-chords.spec.js
@@ -87,8 +87,17 @@ describe('parseSong - chords', () => {
 	test('parses multiple sub-beat groups', () => {
 		const parsed = parseSong(song('C.. [Am G] [F E]'));
 		const bar = parsed.allLines[0].model.allBars[0];
-		const subBeatChords = bar.allChords.filter((c) => c.isInSubBeatGroup);
-		expect(subBeatChords.length).toBe(4);
+		expect(bar.allChords).toHaveLength(5);
+		expect(bar.allChords[0].isInSubBeatGroup).toBe(false);
+		expect(bar.allChords[0].string).toBe('C..');
+		expect(bar.allChords[1].isInSubBeatGroup).toBe(true);
+		expect(bar.allChords[1].isFirstOfSubBeat).toBe(true);
+		expect(bar.allChords[2].isInSubBeatGroup).toBe(true);
+		expect(bar.allChords[2].isLastOfSubBeat).toBe(true);
+		expect(bar.allChords[3].isInSubBeatGroup).toBe(true);
+		expect(bar.allChords[3].isFirstOfSubBeat).toBe(true);
+		expect(bar.allChords[4].isInSubBeatGroup).toBe(true);
+		expect(bar.allChords[4].isLastOfSubBeat).toBe(true);
 	});
 
 	test('parses positioned chords with _ markers', () => {
@@ -96,14 +105,13 @@ describe('parseSong - chords', () => {
 		expect(parsed.allLines[0].type).toBe('chord');
 		expect(parsed.allLines[0].model.hasPositionedChords).toBe(true);
 		expect(parsed.allLines[1].type).toBe('lyric');
-		expect(parsed.allLines[1].model.chordPositions.length).toBeGreaterThan(
-			0
-		);
+		expect(parsed.allLines[1].model.chordPositions).toEqual([0, 8, 10, 13, 22]);
+		expect(parsed.allLines[1].model.lyrics).toBe(' Mother Mary comes to me');
 	});
 
 	test('allChords aggregates unique chords with occurrences and duration', () => {
 		const parsed = parseSong(song('C G C Am'));
-		expect(parsed.allChords.length).toBeGreaterThanOrEqual(2);
+		expect(parsed.allChords).toHaveLength(3);
 		const chordC = parsed.allChords.find(
 			(c) => c.model.formatted.rootNote === 'C' && !c.model.formatted.bassNote
 		);
@@ -114,10 +122,11 @@ describe('parseSong - chords', () => {
 
 	test('allChords marks first and last chord', () => {
 		const parsed = parseSong(song('C G Am'));
-		const first = parsed.allChords.find((c) => c.isFirst);
-		const last = parsed.allChords.find((c) => c.isLast);
-		expect(first).toBeDefined();
-		expect(last).toBeDefined();
+		expect(parsed.allChords).toHaveLength(3);
+		expect(parsed.allChords[0].isFirst).toBe(true);
+		expect(parsed.allChords[0].model.formatted.rootNote).toBe('C');
+		expect(parsed.allChords[2].isLast).toBe(true);
+		expect(parsed.allChords[2].model.formatted.rootNote).toBe('A');
 	});
 
 	test('chord beat property indicates position in bar', () => {

--- a/packages/chord-mark/tests/integration-public-api/parseSong-chords.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/parseSong-chords.spec.js
@@ -1,0 +1,144 @@
+import { parseSong } from '../../src/chordMark';
+import song from './helpers/songInput';
+import {
+	singleChord,
+	multipleChords,
+	multipleBars,
+	barRepeat,
+	chordLineRepeat,
+	noChord,
+	subBeatGroup,
+	multipleSubBeatGroups,
+	positionedChords,
+} from './fixtures/songs';
+
+describe('parseSong - chords', () => {
+	test('parses a single chord line', () => {
+		const parsed = parseSong(singleChord());
+		expect(parsed.allLines).toHaveLength(1);
+		expect(parsed.allLines[0].type).toBe('chord');
+		expect(parsed.allLines[0].model.allBars).toHaveLength(1);
+		expect(parsed.allLines[0].model.allBars[0].allChords).toHaveLength(1);
+		expect(parsed.allLines[0].model.allBars[0].allChords[0].duration).toBe(
+			4
+		);
+	});
+
+	test('parses multiple chords with beat dots', () => {
+		const parsed = parseSong(multipleChords());
+		const bar = parsed.allLines[0].model.allBars[0];
+		expect(bar.allChords).toHaveLength(2);
+		expect(bar.allChords[0].duration).toBe(2);
+		expect(bar.allChords[1].duration).toBe(2);
+		expect(bar.hasUnevenChordsDurations).toBe(false);
+	});
+
+	test('parses multiple bars (one chord per bar)', () => {
+		const parsed = parseSong(multipleBars());
+		expect(parsed.allLines[0].model.allBars).toHaveLength(4);
+	});
+
+	test('parses bar repeat (%)', () => {
+		const parsed = parseSong(song('C G %'));
+		const bars = parsed.allLines[0].model.allBars;
+		expect(bars).toHaveLength(3);
+		expect(bars[0].isRepeated).toBe(false);
+		expect(bars[1].isRepeated).toBe(false);
+		expect(bars[2].isRepeated).toBe(true);
+	});
+
+	test('parses chord line repeat (%%)', () => {
+		// %% repeats the 2nd-to-last chord line (% = last, %% = 2nd-to-last)
+		const parsed = parseSong(
+			song('C.. G..', 'First line', 'Am.. F..', 'Second line', '%%')
+		);
+		const chordLines = parsed.allLines.filter((l) => l.type === 'chord');
+		expect(chordLines).toHaveLength(3);
+		expect(chordLines[0].isFromChordLineRepeater).toBeFalsy();
+		expect(chordLines[1].isFromChordLineRepeater).toBeFalsy();
+		expect(chordLines[2].isFromChordLineRepeater).toBe(true);
+	});
+
+	test('parses no-chord (NC)', () => {
+		const parsed = parseSong(song('C NC'));
+		const bars = parsed.allLines[0].model.allBars;
+		expect(bars).toHaveLength(2);
+		// NC chords have a special model structure
+		expect(bars[0].allChords[0].string).toBe('C');
+		expect(bars[1].allChords[0].string).toBe('NC');
+	});
+
+	test('parses sub-beat groups', () => {
+		const parsed = parseSong(song('C... [Am G]'));
+		const bar = parsed.allLines[0].model.allBars[0];
+		expect(bar.allChords).toHaveLength(3);
+		expect(bar.allChords[0].isInSubBeatGroup).toBe(false);
+		expect(bar.allChords[0].duration).toBe(3);
+		expect(bar.allChords[1].isInSubBeatGroup).toBe(true);
+		expect(bar.allChords[1].isFirstOfSubBeat).toBe(true);
+		expect(bar.allChords[1].isLastOfSubBeat).toBe(false);
+		expect(bar.allChords[1].duration).toBe(0.5);
+		expect(bar.allChords[2].isInSubBeatGroup).toBe(true);
+		expect(bar.allChords[2].isFirstOfSubBeat).toBe(false);
+		expect(bar.allChords[2].isLastOfSubBeat).toBe(true);
+		expect(bar.allChords[2].duration).toBe(0.5);
+	});
+
+	test('parses multiple sub-beat groups', () => {
+		const parsed = parseSong(song('C.. [Am G] [F E]'));
+		const bar = parsed.allLines[0].model.allBars[0];
+		const subBeatChords = bar.allChords.filter((c) => c.isInSubBeatGroup);
+		expect(subBeatChords.length).toBe(4);
+	});
+
+	test('parses positioned chords with _ markers', () => {
+		const parsed = parseSong(positionedChords());
+		expect(parsed.allLines[0].type).toBe('chord');
+		expect(parsed.allLines[0].model.hasPositionedChords).toBe(true);
+		expect(parsed.allLines[1].type).toBe('lyric');
+		expect(parsed.allLines[1].model.chordPositions.length).toBeGreaterThan(
+			0
+		);
+	});
+
+	test('allChords aggregates unique chords with occurrences and duration', () => {
+		const parsed = parseSong(song('C G C Am'));
+		expect(parsed.allChords.length).toBeGreaterThanOrEqual(2);
+		const chordC = parsed.allChords.find(
+			(c) => c.model.formatted.rootNote === 'C' && !c.model.formatted.bassNote
+		);
+		expect(chordC).toBeDefined();
+		expect(chordC.occurrences).toBe(2);
+		expect(chordC.duration).toBe(8);
+	});
+
+	test('allChords marks first and last chord', () => {
+		const parsed = parseSong(song('C G Am'));
+		const first = parsed.allChords.find((c) => c.isFirst);
+		const last = parsed.allChords.find((c) => c.isLast);
+		expect(first).toBeDefined();
+		expect(last).toBeDefined();
+	});
+
+	test('chord beat property indicates position in bar', () => {
+		const parsed = parseSong(song('C. D. E. F.'));
+		const chords = parsed.allLines[0].model.allBars[0].allChords;
+		expect(chords[0].beat).toBe(1);
+		expect(chords[1].beat).toBe(2);
+		expect(chords[2].beat).toBe(3);
+		expect(chords[3].beat).toBe(4);
+	});
+
+	test('hasUnevenChordsDurations flag is set correctly', () => {
+		const parsed = parseSong(song('C... G.'));
+		const bar = parsed.allLines[0].model.allBars[0];
+		expect(bar.hasUnevenChordsDurations).toBe(true);
+	});
+
+	test('bar timeSignature defaults to 4/4', () => {
+		const parsed = parseSong(song('C.. G..'));
+		const bar = parsed.allLines[0].model.allBars[0];
+		expect(bar.timeSignature.string).toBe('4/4');
+		expect(bar.timeSignature.beatCount).toBe(4);
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/parseSong-errors.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/parseSong-errors.spec.js
@@ -1,0 +1,75 @@
+import { parseSong } from '../../src/chordMark';
+import song from './helpers/songInput';
+
+describe('parseSong - error recovery', () => {
+	// parseSong catches chord parsing errors and falls back to treating
+	// the line as a lyric. This is by design — errors are only thrown
+	// when calling parseChordLine directly (unit test territory).
+
+	describe('invalid beat count falls back to lyric', () => {
+		test.each([
+			['1 dot', 'C.'],
+			['2 dots', 'C..'],
+			['3 dots', 'C...'],
+			['5 dots', 'C.....'],
+			['2 chords / 3 beats', 'C. D..'],
+			['2 chords / 5 beats', 'C... D..'],
+		])('%s: "%s" is treated as lyric', (title, input) => {
+			const parsed = parseSong(song(input));
+			expect(parsed.allLines[0].type).toBe('lyric');
+		});
+	});
+
+	describe('invalid sub-beat group falls back to lyric', () => {
+		test.each([
+			['duration in group', 'A... [B7. D7.]'],
+			['duration in first', 'A... [B7. D7]'],
+			['duration in second', 'A... [B7 D7.]'],
+			['unclosed bracket', 'A... [B7 D7'],
+			['nested bracket', 'A... [B7 [D7'],
+			['single chord', 'A... [C]'],
+			['stray closing at start', ']A.. B7. D7.'],
+			['stray closing at end', 'A... B7 D7]'],
+		])('%s: "%s" is treated as lyric', (title, input) => {
+			const parsed = parseSong(song(input));
+			expect(parsed.allLines[0].type).toBe('lyric');
+		});
+	});
+
+	describe('invalid bar repeat falls back to lyric', () => {
+		test.each([
+			['no bar to repeat', '% A'],
+			['whitespace before %', ' % A'],
+			['previous bar incomplete', 'A... % A'],
+		])('%s: "%s" is treated as lyric', (title, input) => {
+			const parsed = parseSong(song(input));
+			expect(parsed.allLines[0].type).toBe('lyric');
+		});
+	});
+
+	describe('invalid chord repetition falls back to lyric', () => {
+		test.each([
+			['same chord repeated', 'A. A...'],
+			['same chord equal duration', 'A.. A..'],
+			['same chord reversed', 'A... A.'],
+		])('%s: "%s" is treated as lyric', (title, input) => {
+			const parsed = parseSong(song(input));
+			expect(parsed.allLines[0].type).toBe('lyric');
+		});
+	});
+
+	describe('invalid inputs do not produce chord lines', () => {
+		test('no chords detected in invalid chord-like input', () => {
+			const parsed = parseSong(song('C.'));
+			expect(parsed.allChords).toEqual([]);
+		});
+
+		test('valid chords on other lines still work', () => {
+			const parsed = parseSong(song('C.', 'G Am'));
+			// C. falls back to lyric, but G Am is a valid chord line
+			expect(parsed.allLines[0].type).toBe('lyric');
+			expect(parsed.allLines[1].type).toBe('chord');
+			expect(parsed.allChords.length).toBeGreaterThan(0);
+		});
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/parseSong-keys.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/parseSong-keys.spec.js
@@ -1,0 +1,79 @@
+import { parseSong } from '../../src/chordMark';
+import song from './helpers/songInput';
+import {
+	explicitKey,
+	explicitKeyMinor,
+	multipleKeyChanges,
+	autoDetectedKey,
+} from './fixtures/songs';
+
+describe('parseSong - keys', () => {
+	test('parses explicit key declaration', () => {
+		const parsed = parseSong(explicitKey());
+		const keyLine = parsed.allLines.find(
+			(l) => l.type === 'keyDeclaration'
+		);
+		expect(keyLine).toBeDefined();
+		expect(keyLine.string).toBe('key G');
+		expect(keyLine.model.string).toBe('G');
+		expect(keyLine.model.accidental).toBe('sharp');
+	});
+
+	test('parses minor key declaration', () => {
+		const parsed = parseSong(explicitKeyMinor());
+		const keyLine = parsed.allLines.find(
+			(l) => l.type === 'keyDeclaration'
+		);
+		expect(keyLine.model.string).toBe('Am');
+		expect(keyLine.model.accidental).toBe('flat');
+	});
+
+	test('allKeys.explicit contains all declared keys', () => {
+		const parsed = parseSong(multipleKeyChanges());
+		expect(parsed.allKeys.explicit).toHaveLength(2);
+		expect(parsed.allKeys.explicit[0].string).toBe('C');
+		expect(parsed.allKeys.explicit[1].string).toBe('G');
+	});
+
+	test('auto-detects key from chords', () => {
+		const parsed = parseSong(autoDetectedKey());
+		expect(parsed.allKeys.auto).toBeDefined();
+	});
+
+	test('explicit key sets originalKey on chord lines', () => {
+		const parsed = parseSong(explicitKey());
+		const chordLine = parsed.allLines.find((l) => l.type === 'chord');
+		expect(chordLine.model.originalKey).toBeDefined();
+		expect(chordLine.model.originalKey.string).toBe('G');
+	});
+
+	describe.each([
+		['key A', 'A', 'sharp'],
+		['key Am', 'Am', 'flat'],
+		['key Bb', 'Bb', 'flat'],
+		['key F#', 'F#', 'sharp'],
+		['key C#m', 'C#m', 'sharp'],
+		['key Abm', 'Abm', 'flat'],
+	])('parses %s', (keyInput, expectedString, expectedAccidental) => {
+		test(`key ${expectedString} accidental=${expectedAccidental}`, () => {
+			const parsed = parseSong(song(keyInput, 'C'));
+			const keyLine = parsed.allLines.find(
+				(l) => l.type === 'keyDeclaration'
+			);
+			expect(keyLine.model.string).toBe(expectedString);
+			expect(keyLine.model.accidental).toBe(expectedAccidental);
+		});
+	});
+
+	test('key affects chord parsing in allChords', () => {
+		const parsed = parseSong(
+			song('key G', 'C.. G..', 'key Am', 'Am.. Dm..')
+		);
+		expect(parsed.allChords.length).toBeGreaterThan(0);
+	});
+
+	test('no key declaration results in empty explicit keys', () => {
+		const parsed = parseSong(song('C G Am'));
+		expect(parsed.allKeys.explicit).toEqual([]);
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/parseSong-keys.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/parseSong-keys.spec.js
@@ -65,11 +65,19 @@ describe('parseSong - keys', () => {
 		});
 	});
 
-	test('key affects chord parsing in allChords', () => {
+	test('key affects originalKey on chord lines', () => {
 		const parsed = parseSong(
 			song('key G', 'C.. G..', 'key Am', 'Am.. Dm..')
 		);
-		expect(parsed.allChords.length).toBeGreaterThan(0);
+		const chordLines = parsed.allLines.filter(
+			(l) => l.type === 'chord'
+		);
+		expect(chordLines).toHaveLength(2);
+		expect(chordLines[0].model.originalKey.string).toBe('G');
+		expect(chordLines[0].model.originalKey.accidental).toBe('sharp');
+		expect(chordLines[1].model.originalKey.string).toBe('Am');
+		expect(chordLines[1].model.originalKey.accidental).toBe('flat');
+		expect(parsed.allChords).toHaveLength(4);
 	});
 
 	test('no key declaration results in empty explicit keys', () => {

--- a/packages/chord-mark/tests/integration-public-api/parseSong-sections.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/parseSong-sections.spec.js
@@ -1,0 +1,105 @@
+import { parseSong } from '../../src/chordMark';
+import song from './helpers/songInput';
+import {
+	sectionWithContent,
+	sectionCopy,
+	sectionMultiply,
+	customSection,
+} from './fixtures/songs';
+
+describe('parseSong - sections', () => {
+	describe.each([
+		['#v', 'v'],
+		['#c', 'c'],
+		['#i', 'i'],
+		['#b', 'b'],
+		['#o', 'o'],
+		['#s', 's'],
+		['#a', 'a'],
+		['#p', 'p'],
+		['#u', 'u'],
+	])('parses section label %s', (input, expectedLabel) => {
+		test(`recognizes ${input} as sectionLabel`, () => {
+			const parsed = parseSong(song(input));
+			expect(parsed.allLines[0].type).toBe('sectionLabel');
+			expect(parsed.allLines[0].model.label).toBe(expectedLabel);
+		});
+	});
+
+	test('parses section with content', () => {
+		const parsed = parseSong(sectionWithContent());
+		const sectionLabels = parsed.allLines.filter(
+			(l) => l.type === 'sectionLabel'
+		);
+		expect(sectionLabels).toHaveLength(2);
+		expect(sectionLabels[0].model.label).toBe('v');
+		expect(sectionLabels[1].model.label).toBe('c');
+	});
+
+	test('section copy repeats chord lines', () => {
+		const parsed = parseSong(sectionCopy());
+		const sectionLabels = parsed.allLines.filter(
+			(l) => l.type === 'sectionLabel'
+		);
+		expect(sectionLabels).toHaveLength(3);
+
+		// Copied sections should have chords from auto-repeat
+		const chordLines = parsed.allLines.filter((l) => l.type === 'chord');
+		expect(chordLines.length).toBeGreaterThanOrEqual(2);
+	});
+
+	test('section copy marks lines as isFromSectionCopy', () => {
+		const parsed = parseSong(sectionCopy());
+		const copiedLines = parsed.allLines.filter(
+			(l) => l.isFromSectionCopy
+		);
+		expect(copiedLines.length).toBeGreaterThan(0);
+	});
+
+	test('section multiply x2 duplicates section lines', () => {
+		const parsed = parseSong(sectionMultiply());
+		const sectionLabels = parsed.allLines.filter(
+			(l) => l.type === 'sectionLabel'
+		);
+		// x2 creates 2 section label lines (original + multiplied)
+		expect(sectionLabels).toHaveLength(2);
+		expect(sectionLabels[0].model.multiplyTimes).toBe(2);
+		expect(sectionLabels[1].isFromSectionMultiply).toBe(true);
+	});
+
+	test('section multiply marks lines as isFromSectionMultiply', () => {
+		const parsed = parseSong(sectionMultiply());
+		const multipliedLines = parsed.allLines.filter(
+			(l) => l.isFromSectionMultiply
+		);
+		expect(multipliedLines.length).toBeGreaterThan(0);
+	});
+
+	test('parses custom section label', () => {
+		const parsed = parseSong(customSection());
+		expect(parsed.allLines[0].type).toBe('sectionLabel');
+		expect(parsed.allLines[0].model.label).toBe('special');
+		expect(parsed.allLines[0].model.string).toBe('#special');
+	});
+
+	test('section label with index', () => {
+		const parsed = parseSong(song('#v', '#v', '#v'));
+		const sectionLabels = parsed.allLines.filter(
+			(l) => l.type === 'sectionLabel'
+		);
+		expect(sectionLabels).toHaveLength(3);
+		expect(sectionLabels[0].index).toBe(1);
+		expect(sectionLabels[1].index).toBe(2);
+		expect(sectionLabels[2].index).toBe(3);
+	});
+
+	test('auto-repeat chords marks lines as isFromAutoRepeatChords', () => {
+		const parsed = parseSong(
+			song('#v', 'C G', 'line1', '', '#v', 'line2')
+		);
+		const autoRepeatLines = parsed.allLines.filter(
+			(l) => l.isFromAutoRepeatChords
+		);
+		expect(autoRepeatLines.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/parseSong-sections.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/parseSong-sections.spec.js
@@ -36,24 +36,36 @@ describe('parseSong - sections', () => {
 		expect(sectionLabels[1].model.label).toBe('c');
 	});
 
-	test('section copy repeats chord lines', () => {
+	test('section copy repeats chord and lyric lines', () => {
 		const parsed = parseSong(sectionCopy());
 		const sectionLabels = parsed.allLines.filter(
 			(l) => l.type === 'sectionLabel'
 		);
 		expect(sectionLabels).toHaveLength(3);
 
-		// Copied sections should have chords from auto-repeat
+		// Each section gets its own chord line (original + 2 copies)
 		const chordLines = parsed.allLines.filter((l) => l.type === 'chord');
-		expect(chordLines.length).toBeGreaterThanOrEqual(2);
+		expect(chordLines).toHaveLength(3);
+		// Copied chord lines have the same content
+		expect(chordLines[1].string).toBe('C G');
+		expect(chordLines[2].string).toBe('C G');
 	});
 
-	test('section copy marks lines as isFromSectionCopy', () => {
+	test('section copy marks exactly the copied lines as isFromSectionCopy', () => {
 		const parsed = parseSong(sectionCopy());
 		const copiedLines = parsed.allLines.filter(
 			(l) => l.isFromSectionCopy
 		);
-		expect(copiedLines.length).toBeGreaterThan(0);
+		// 2 copied sections × 3 lines each (sectionLabel + chord + lyric)
+		expect(copiedLines).toHaveLength(6);
+		expect(copiedLines.map((l) => l.type)).toEqual([
+			'sectionLabel',
+			'chord',
+			'lyric',
+			'sectionLabel',
+			'chord',
+			'lyric',
+		]);
 	});
 
 	test('section multiply x2 duplicates section lines', () => {
@@ -67,12 +79,18 @@ describe('parseSong - sections', () => {
 		expect(sectionLabels[1].isFromSectionMultiply).toBe(true);
 	});
 
-	test('section multiply marks lines as isFromSectionMultiply', () => {
+	test('section multiply marks exactly the multiplied lines', () => {
 		const parsed = parseSong(sectionMultiply());
 		const multipliedLines = parsed.allLines.filter(
 			(l) => l.isFromSectionMultiply
 		);
-		expect(multipliedLines.length).toBeGreaterThan(0);
+		// x2 creates 1 additional copy: sectionLabel + chord + lyric = 3 lines
+		expect(multipliedLines).toHaveLength(3);
+		expect(multipliedLines.map((l) => l.type)).toEqual([
+			'sectionLabel',
+			'chord',
+			'lyric',
+		]);
 	});
 
 	test('parses custom section label', () => {
@@ -93,13 +111,16 @@ describe('parseSong - sections', () => {
 		expect(sectionLabels[2].index).toBe(3);
 	});
 
-	test('auto-repeat chords marks lines as isFromAutoRepeatChords', () => {
+	test('auto-repeat chords marks exactly the repeated chord line', () => {
 		const parsed = parseSong(
 			song('#v', 'C G', 'line1', '', '#v', 'line2')
 		);
 		const autoRepeatLines = parsed.allLines.filter(
 			(l) => l.isFromAutoRepeatChords
 		);
-		expect(autoRepeatLines.length).toBeGreaterThan(0);
+		// Only the chord line in verse 2 is auto-repeated
+		expect(autoRepeatLines).toHaveLength(1);
+		expect(autoRepeatLines[0].type).toBe('chord');
+		expect(autoRepeatLines[0].string).toBe('C G');
 	});
 });

--- a/packages/chord-mark/tests/integration-public-api/parseSong-time-signatures.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/parseSong-time-signatures.spec.js
@@ -1,0 +1,81 @@
+import { parseSong } from '../../src/chordMark';
+import song from './helpers/songInput';
+
+describe('parseSong - time signatures', () => {
+	test('parses standalone time signature line', () => {
+		const parsed = parseSong(song('4/4', 'C'));
+		expect(parsed.allLines[0].type).toBe('timeSignature');
+		expect(parsed.allLines[0].string).toBe('4/4');
+		expect(parsed.allLines[0].model.string).toBe('4/4');
+		expect(parsed.allLines[0].model.beatCount).toBe(4);
+	});
+
+	test('default time signature is 4/4', () => {
+		const parsed = parseSong(song('C.. G..'));
+		const bar = parsed.allLines[0].model.allBars[0];
+		expect(bar.timeSignature.string).toBe('4/4');
+	});
+
+	describe.each([
+		['1/2', 2],
+		['2/2', 4],
+		['3/2', 6],
+		['4/2', 8],
+		['1/4', 1],
+		['2/4', 2],
+		['3/4', 3],
+		['4/4', 4],
+		['5/4', 5],
+		['6/4', 6],
+		['7/4', 7],
+		['9/4', 9],
+		['10/4', 10],
+		['3/8', 1],
+		['4/8', 4 / 3],
+		['5/8', 5 / 3],
+		['6/8', 2],
+		['7/8', 7 / 3],
+		['9/8', 3],
+		['12/8', 4],
+	])('parses %s time signature', (ts, expectedBeatCount) => {
+		test(`${ts} has beatCount ${expectedBeatCount}`, () => {
+			const parsed = parseSong(song(ts, 'C'));
+			const tsLine = parsed.allLines.find(
+				(l) => l.type === 'timeSignature'
+			);
+			expect(tsLine).toBeDefined();
+			expect(tsLine.model.string).toBe(ts);
+			expect(tsLine.model.beatCount).toBe(expectedBeatCount);
+		});
+	});
+
+	test('3/4 affects chord parsing', () => {
+		const parsed = parseSong(song('3/4', 'C. D. E.'));
+		const bar = parsed.allLines[1].model.allBars[0];
+		expect(bar.timeSignature.string).toBe('3/4');
+		expect(bar.allChords).toHaveLength(3);
+		bar.allChords.forEach((chord) => {
+			expect(chord.duration).toBe(1);
+		});
+	});
+
+	test('inline time signature change', () => {
+		const parsed = parseSong(song('4/4', '2/4 G 4/4 Am'));
+		const chordLine = parsed.allLines[1];
+		expect(chordLine.type).toBe('chord');
+		const bars = chordLine.model.allBars;
+		expect(bars).toHaveLength(2);
+		expect(bars[0].timeSignature.string).toBe('2/4');
+		expect(bars[1].timeSignature.string).toBe('4/4');
+		expect(bars[0].lineHadTimeSignatureChange).toBe(true);
+	});
+
+	test('6/8 time signature', () => {
+		const parsed = parseSong(song('6/8', 'Am F'));
+		const bars = parsed.allLines[1].model.allBars;
+		expect(bars[0].timeSignature.string).toBe('6/8');
+		expect(bars).toHaveLength(2);
+		expect(bars[0].allChords[0].duration).toBe(2);
+		expect(bars[1].allChords[0].duration).toBe(2);
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/renderSong-advanced.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-advanced.spec.js
@@ -1,0 +1,120 @@
+import { parseSong, renderSong, lineTypes } from '../../src/chordMark';
+import toText from './helpers/toText';
+import song from './helpers/songInput';
+
+function render(input, options = {}) {
+	return renderSong(parseSong(input), options);
+}
+
+describe('renderSong - advanced', () => {
+	describe('wrapChordLyricLines', () => {
+		test('wraps chord+lyric pairs when enabled', () => {
+			const input = song(
+				'C... CM7. F',
+				"_Imagine there's _no hea_ven"
+			);
+			const rendered = render(input, { wrapChordLyricLines: true });
+			// When wrapped, chord and lyric lines are merged into a single element
+			expect(rendered).toContain('cmChordLyricLine');
+		});
+
+		test('does not wrap when disabled (default)', () => {
+			const input = song(
+				'C... CM7. F',
+				"_Imagine there's _no hea_ven"
+			);
+			const rendered = render(input, { wrapChordLyricLines: false });
+			expect(rendered).not.toContain('cmChordLyricLine');
+		});
+	});
+
+	describe('customRenderer', () => {
+		test('returns result of custom renderer', () => {
+			const customRenderer = jest.fn().mockReturnValue('custom output');
+			const rendered = render(song('#v', 'C G', 'line1'), {
+				customRenderer,
+			});
+			expect(rendered).toBe('custom output');
+		});
+
+		test('passes allLines and allRenderedLines to custom renderer', () => {
+			const customRenderer = jest.fn().mockReturnValue('');
+			render(song('#v', 'C G', 'line1'), { customRenderer });
+
+			const allLines = customRenderer.mock.calls[0][0];
+			const allRenderedLines = customRenderer.mock.calls[0][1];
+
+			expect(allLines.length).toBe(3);
+			expect(allLines[0].type).toBe(lineTypes.SECTION_LABEL);
+			expect(allLines[1].type).toBe(lineTypes.CHORD);
+			expect(allLines[2].type).toBe(lineTypes.LYRIC);
+
+			expect(allRenderedLines.length).toBe(3);
+		});
+
+		test('passes options to custom renderer', () => {
+			const customRenderer = jest.fn().mockReturnValue('');
+			render(song('#v', 'C G', 'line1'), {
+				customRenderer,
+				alignChordsWithLyrics: true,
+				alignBars: false,
+			});
+
+			const options = customRenderer.mock.calls[0][2];
+			expect(options).toStrictEqual({
+				alignChordsWithLyrics: true,
+				alignBars: false,
+			});
+		});
+	});
+
+	describe('key declaration rendering', () => {
+		test('renders key declaration as "key: X"', () => {
+			const text = toText(render(song('key C', 'C G')));
+			expect(text).toContain('key: C');
+		});
+
+		test('renders multiple key declarations', () => {
+			const text = toText(
+				render(
+					song('key C', 'C G', 'line', 'key G', 'G D', 'line')
+				)
+			);
+			expect(text).toContain('key: C');
+			expect(text).toContain('key: G');
+		});
+	});
+
+	describe('CSS classes for source types', () => {
+		test('isFromSectionMultiply class', () => {
+			const rendered = render(song('#v x2', 'C G', 'line'), {
+				expandSectionMultiply: true,
+			});
+			expect(rendered).toContain('cmLine--isFromSectionMultiply');
+		});
+
+		test('isFromAutoRepeatChords class', () => {
+			const rendered = render(
+				song('#v', 'C G', 'line1', '', '#v', 'line2'),
+				{ autoRepeatChords: true, alignBars: false }
+			);
+			expect(rendered).toContain('cmLine--isFromAutoRepeatChords');
+		});
+
+		test('isFromChordLineRepeater class', () => {
+			// %% needs 2 preceding chord lines to work
+			const rendered = render(
+				song('C G', 'line1', 'Am F', 'line2', '%%', 'line3')
+			);
+			expect(rendered).toContain('cmLine--isFromChordLineRepeater');
+		});
+
+		test('isFromSectionCopy class', () => {
+			const rendered = render(
+				song('#v', 'C G', 'line', '#v'),
+				{ expandSectionCopy: true }
+			);
+			expect(rendered).toContain('cmLine--isFromSectionCopy');
+		});
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/renderSong-alignment.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-alignment.spec.js
@@ -9,16 +9,10 @@ function render(input, options = {}) {
 describe('renderSong - alignment', () => {
 	describe('alignBars', () => {
 		test('aligned bars pad shorter chords with spaces', () => {
-			const textAligned = toText(
+			const text = toText(
 				render(song('C G Am F'), { alignBars: true })
 			);
-			const textNonAligned = toText(
-				render(song('C G Am F'), { alignBars: false })
-			);
-			// Aligned output is wider because shorter chords get padded
-			expect(textAligned.length).toBeGreaterThan(textNonAligned.length);
-			// Aligned bars have consistent padding
-			expect(textAligned).toBe('|C     |G     |Am     |F     |');
+			expect(text).toBe('|C     |G     |Am     |F     |');
 		});
 
 		test('non-aligned bars use simple spacing', () => {
@@ -39,11 +33,9 @@ describe('renderSong - alignment', () => {
 			const text = toText(
 				render(input, { alignChordsWithLyrics: true })
 			);
-			const lines = text.split('\n');
-			// Chord line should be aligned with lyrics
-			expect(lines[1]).toContain('C...');
-			expect(lines[1]).toContain('CM7.');
-			expect(lines[1]).toContain('F');
+			expect(text).toBe(
+				"Verse\n|C...            CM7. |F  |\n Imagine there's no heaven"
+			);
 		});
 
 		test('ignores _ positions when disabled', () => {
@@ -52,14 +44,12 @@ describe('renderSong - alignment', () => {
 				'C... CM7. F',
 				"_Imagine there's _no hea_ven"
 			);
-			const textEnabled = toText(
-				render(input, { alignChordsWithLyrics: true })
-			);
-			const textDisabled = toText(
+			const text = toText(
 				render(input, { alignChordsWithLyrics: false })
 			);
-			// Different alignment produces different output
-			expect(textEnabled).not.toEqual(textDisabled);
+			expect(text).toBe(
+				"Verse\n|C...    CM7.|F     |\nImagine there's no heaven"
+			);
 		});
 
 		test('positioned chords strip _ from lyrics', () => {

--- a/packages/chord-mark/tests/integration-public-api/renderSong-alignment.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-alignment.spec.js
@@ -1,0 +1,75 @@
+import { parseSong, renderSong } from '../../src/chordMark';
+import toText from './helpers/toText';
+import song from './helpers/songInput';
+
+function render(input, options = {}) {
+	return renderSong(parseSong(input), options);
+}
+
+describe('renderSong - alignment', () => {
+	describe('alignBars', () => {
+		test('aligned bars pad shorter chords with spaces', () => {
+			const textAligned = toText(
+				render(song('C G Am F'), { alignBars: true })
+			);
+			const textNonAligned = toText(
+				render(song('C G Am F'), { alignBars: false })
+			);
+			// Aligned output is wider because shorter chords get padded
+			expect(textAligned.length).toBeGreaterThan(textNonAligned.length);
+			// Aligned bars have consistent padding
+			expect(textAligned).toBe('|C     |G     |Am     |F     |');
+		});
+
+		test('non-aligned bars use simple spacing', () => {
+			const text = toText(
+				render(song('C G Am F'), { alignBars: false })
+			);
+			expect(text).toBe('|C  |G  |Am  |F  |');
+		});
+	});
+
+	describe('alignChordsWithLyrics', () => {
+		test('aligns chords with lyric positions when enabled', () => {
+			const input = song(
+				'#v',
+				'C... CM7. F',
+				'_Imagine there\'s _no hea_ven'
+			);
+			const text = toText(
+				render(input, { alignChordsWithLyrics: true })
+			);
+			const lines = text.split('\n');
+			// Chord line should be aligned with lyrics
+			expect(lines[1]).toContain('C...');
+			expect(lines[1]).toContain('CM7.');
+			expect(lines[1]).toContain('F');
+		});
+
+		test('ignores _ positions when disabled', () => {
+			const input = song(
+				'#v',
+				'C... CM7. F',
+				"_Imagine there's _no hea_ven"
+			);
+			const textEnabled = toText(
+				render(input, { alignChordsWithLyrics: true })
+			);
+			const textDisabled = toText(
+				render(input, { alignChordsWithLyrics: false })
+			);
+			// Different alignment produces different output
+			expect(textEnabled).not.toEqual(textDisabled);
+		});
+
+		test('positioned chords strip _ from lyrics', () => {
+			const input = song(
+				'C... CM7. F',
+				"_Imagine there's _no hea_ven"
+			);
+			const text = toText(render(input));
+			expect(text).toContain("Imagine there's no heaven");
+			expect(text).not.toContain('_');
+		});
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/renderSong-alignment.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-alignment.spec.js
@@ -34,7 +34,9 @@ describe('renderSong - alignment', () => {
 				render(input, { alignChordsWithLyrics: true })
 			);
 			expect(text).toBe(
-				"Verse\n|C...            CM7. |F  |\n Imagine there's no heaven"
+				'Verse\n' +
+				'|C...            CM7. |F  |\n' +
+				" Imagine there's no heaven"
 			);
 		});
 
@@ -48,7 +50,9 @@ describe('renderSong - alignment', () => {
 				render(input, { alignChordsWithLyrics: false })
 			);
 			expect(text).toBe(
-				"Verse\n|C...    CM7.|F     |\nImagine there's no heaven"
+				'Verse\n' +
+				'|C...    CM7.|F     |\n' +
+				"Imagine there's no heaven"
 			);
 		});
 

--- a/packages/chord-mark/tests/integration-public-api/renderSong-basics.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-basics.spec.js
@@ -1,0 +1,69 @@
+import { parseSong, renderSong } from '../../src/chordMark';
+import toText from './helpers/toText';
+import song from './helpers/songInput';
+
+function render(input, options = {}) {
+	return renderSong(parseSong(input), options);
+}
+
+describe('renderSong - basics', () => {
+	test('renders with default options', () => {
+		const rendered = render(song('C G', 'A lyric line'));
+		expect(rendered).toContain('<div');
+		expect(rendered).toContain('</div>');
+	});
+
+	test('renders lyrics-only song', () => {
+		const rendered = render(
+			song('First line', '', 'Second line')
+		);
+		const text = toText(rendered);
+		expect(text).toContain('First line');
+		expect(text).toContain('Second line');
+	});
+
+	test('renders empty lines', () => {
+		const rendered = render(song('line1', '', 'line2'));
+		const text = toText(rendered);
+		expect(text).toBe('line1\n\nline2');
+	});
+
+	test('renders chord line with lyrics', () => {
+		const rendered = render(song('C G', 'A lyric'), { alignBars: false });
+		const text = toText(rendered);
+		expect(text).toContain('|C  |G  |');
+		expect(text).toContain('A lyric');
+	});
+
+	test('output is wrapped in song template div', () => {
+		const rendered = render(song('C'));
+		expect(rendered).toMatch(/^<div class="cmSong">/);
+		expect(rendered).toMatch(/<\/div>$/);
+	});
+
+	test('each line is wrapped in a <p> tag', () => {
+		const rendered = render(song('C G', 'A line'));
+		const pTags = rendered.match(/<p/g);
+		expect(pTags.length).toBe(2);
+	});
+
+	test('renders line with cmLine CSS class', () => {
+		const rendered = render(song('C'));
+		expect(rendered).toContain('cmLine');
+	});
+
+	test('renders chord line with cmChordLine CSS class', () => {
+		const rendered = render(song('C'));
+		expect(rendered).toContain('cmChordLine');
+	});
+
+	test('renders lyric line with cmLyricLine CSS class', () => {
+		const rendered = render(song('A lyric'));
+		expect(rendered).toContain('cmLyricLine');
+	});
+
+	test('renders empty line with cmEmptyLine CSS class', () => {
+		const rendered = render(song('line', '', 'line'));
+		expect(rendered).toContain('cmEmptyLine');
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/renderSong-basics.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-basics.spec.js
@@ -9,30 +9,25 @@ function render(input, options = {}) {
 describe('renderSong - basics', () => {
 	test('renders with default options', () => {
 		const rendered = render(song('C G', 'A lyric line'));
-		expect(rendered).toContain('<div');
-		expect(rendered).toContain('</div>');
+		const text = toText(rendered);
+		expect(text).toBe('|C     |G     |\nA lyric line');
 	});
 
 	test('renders lyrics-only song', () => {
-		const rendered = render(
-			song('First line', '', 'Second line')
-		);
-		const text = toText(rendered);
-		expect(text).toContain('First line');
-		expect(text).toContain('Second line');
+		const text = toText(render(song('First line', '', 'Second line')));
+		expect(text).toBe('First line\n\nSecond line');
 	});
 
 	test('renders empty lines', () => {
-		const rendered = render(song('line1', '', 'line2'));
-		const text = toText(rendered);
+		const text = toText(render(song('line1', '', 'line2')));
 		expect(text).toBe('line1\n\nline2');
 	});
 
 	test('renders chord line with lyrics', () => {
-		const rendered = render(song('C G', 'A lyric'), { alignBars: false });
-		const text = toText(rendered);
-		expect(text).toContain('|C  |G  |');
-		expect(text).toContain('A lyric');
+		const text = toText(
+			render(song('C G', 'A lyric'), { alignBars: false })
+		);
+		expect(text).toBe('|C  |G  |\nA lyric');
 	});
 
 	test('output is wrapped in song template div', () => {
@@ -45,11 +40,6 @@ describe('renderSong - basics', () => {
 		const rendered = render(song('C G', 'A line'));
 		const pTags = rendered.match(/<p/g);
 		expect(pTags.length).toBe(2);
-	});
-
-	test('renders line with cmLine CSS class', () => {
-		const rendered = render(song('C'));
-		expect(rendered).toContain('cmLine');
 	});
 
 	test('renders chord line with cmChordLine CSS class', () => {

--- a/packages/chord-mark/tests/integration-public-api/renderSong-basics.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-basics.spec.js
@@ -10,24 +10,38 @@ describe('renderSong - basics', () => {
 	test('renders with default options', () => {
 		const rendered = render(song('C G', 'A lyric line'));
 		const text = toText(rendered);
-		expect(text).toBe('|C     |G     |\nA lyric line');
+		expect(text).toBe(
+			'|C     |G     |\n' +
+			'A lyric line'
+		);
 	});
 
 	test('renders lyrics-only song', () => {
 		const text = toText(render(song('First line', '', 'Second line')));
-		expect(text).toBe('First line\n\nSecond line');
+		expect(text).toBe(
+			'First line\n' +
+			'\n' +
+			'Second line'
+		);
 	});
 
 	test('renders empty lines', () => {
 		const text = toText(render(song('line1', '', 'line2')));
-		expect(text).toBe('line1\n\nline2');
+		expect(text).toBe(
+			'line1\n' +
+			'\n' +
+			'line2'
+		);
 	});
 
 	test('renders chord line with lyrics', () => {
 		const text = toText(
 			render(song('C G', 'A lyric'), { alignBars: false })
 		);
-		expect(text).toBe('|C  |G  |\nA lyric');
+		expect(text).toBe(
+			'|C  |G  |\n' +
+			'A lyric'
+		);
 	});
 
 	test('output is wrapped in song template div', () => {

--- a/packages/chord-mark/tests/integration-public-api/renderSong-chords.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-chords.spec.js
@@ -47,7 +47,10 @@ describe('renderSong - chords', () => {
 			const text = toText(
 				render(input, { printChordsDuration: 'never', alignBars: true })
 			);
-			expect(text).toBe('4/4\n|A7  B    |');
+			expect(text).toBe(
+				'4/4\n' +
+				'|A7  B    |'
+			);
 		});
 
 		test('="uneven" shows dots for uneven durations', () => {
@@ -57,7 +60,10 @@ describe('renderSong - chords', () => {
 					alignBars: true,
 				})
 			);
-			expect(text).toBe('4/4\n|A7.  B...    |');
+			expect(text).toBe(
+				'4/4\n' +
+				'|A7.  B...    |'
+			);
 		});
 
 		test('="always" shows dots for all chords', () => {
@@ -67,7 +73,10 @@ describe('renderSong - chords', () => {
 					alignBars: true,
 				})
 			);
-			expect(text).toBe('4/4\n|A7..   B..   |');
+			expect(text).toBe(
+				'4/4\n' +
+				'|A7..   B..   |'
+			);
 		});
 	});
 

--- a/packages/chord-mark/tests/integration-public-api/renderSong-chords.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-chords.spec.js
@@ -1,0 +1,115 @@
+import { parseSong, renderSong } from '../../src/chordMark';
+import toText from './helpers/toText';
+import song from './helpers/songInput';
+
+function render(input, options = {}) {
+	return renderSong(parseSong(input), options);
+}
+
+describe('renderSong - chords', () => {
+	test('renders single chord', () => {
+		const text = toText(render(song('C'), { alignBars: false }));
+		expect(text).toBe('|C  |');
+	});
+
+	test('renders multiple chords in one bar', () => {
+		const text = toText(
+			render(song('C.. G..'), { alignBars: false })
+		);
+		expect(text).toContain('C');
+		expect(text).toContain('G');
+	});
+
+	test('renders multiple bars', () => {
+		const text = toText(
+			render(song('C G Am F'), { alignBars: false })
+		);
+		expect(text).toBe('|C  |G  |Am  |F  |');
+	});
+
+	test('renders bar repeat as %', () => {
+		const text = toText(
+			render(song('C G Am %'), { alignBars: false })
+		);
+		expect(text).toContain('%');
+	});
+
+	test('renders NC chord', () => {
+		const text = toText(
+			render(song('C NC'), { alignBars: false })
+		);
+		expect(text).toContain('NC');
+	});
+
+	describe('printChordsDuration', () => {
+		const input = song('4/4', 'A7. B...');
+
+		test('="never" hides beat dots', () => {
+			const text = toText(
+				render(input, { printChordsDuration: 'never', alignBars: true })
+			);
+			expect(text).not.toContain('.');
+		});
+
+		test('="uneven" shows dots for uneven durations', () => {
+			const text = toText(
+				render(input, {
+					printChordsDuration: 'uneven',
+					alignBars: true,
+				})
+			);
+			expect(text).toContain('A7.');
+			expect(text).toContain('B...');
+		});
+
+		test('="always" shows dots for all chords', () => {
+			const text = toText(
+				render(song('4/4', 'A7.. B..'), {
+					printChordsDuration: 'always',
+					alignBars: true,
+				})
+			);
+			expect(text).toContain('A7..');
+			expect(text).toContain('B..');
+		});
+	});
+
+	describe('printBarSeparators', () => {
+		test('="never" removes bar separators', () => {
+			const text = toText(
+				render(song('C G'), { printBarSeparators: 'never' })
+			);
+			expect(text).not.toContain('|');
+		});
+
+		test('="always" shows bar separators', () => {
+			const text = toText(
+				render(song('C G'), { printBarSeparators: 'always' })
+			);
+			expect(text).toContain('|');
+		});
+
+		test('="grids" shows separators only for non-positioned chord lines', () => {
+			const input = song(
+				'#v',
+				'A7 %%%',
+				'_A first _line _with _positioned chords',
+				'D7 % A7 %',
+				'A second line without'
+			);
+			const text = toText(render(input, { printBarSeparators: 'grids' }));
+			const lines = text.split('\n');
+			// Non-positioned line should have bar separators
+			expect(lines[3]).toContain('|');
+			// Positioned line should not
+			expect(lines[1]).not.toContain('|');
+		});
+	});
+
+	test('renders repeated bars with %', () => {
+		const text = toText(
+			render(song('A7 % % %'), { alignBars: true })
+		);
+		expect(text).toContain('%');
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/renderSong-chords.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-chords.spec.js
@@ -16,8 +16,7 @@ describe('renderSong - chords', () => {
 		const text = toText(
 			render(song('C.. G..'), { alignBars: false })
 		);
-		expect(text).toContain('C');
-		expect(text).toContain('G');
+		expect(text).toBe('|C  G  |');
 	});
 
 	test('renders multiple bars', () => {
@@ -31,14 +30,14 @@ describe('renderSong - chords', () => {
 		const text = toText(
 			render(song('C G Am %'), { alignBars: false })
 		);
-		expect(text).toContain('%');
+		expect(text).toBe('|C  |G  |Am  |%  |');
 	});
 
 	test('renders NC chord', () => {
 		const text = toText(
 			render(song('C NC'), { alignBars: false })
 		);
-		expect(text).toContain('NC');
+		expect(text).toBe('|C  |NC  |');
 	});
 
 	describe('printChordsDuration', () => {
@@ -48,7 +47,7 @@ describe('renderSong - chords', () => {
 			const text = toText(
 				render(input, { printChordsDuration: 'never', alignBars: true })
 			);
-			expect(text).not.toContain('.');
+			expect(text).toBe('4/4\n|A7  B    |');
 		});
 
 		test('="uneven" shows dots for uneven durations', () => {
@@ -58,8 +57,7 @@ describe('renderSong - chords', () => {
 					alignBars: true,
 				})
 			);
-			expect(text).toContain('A7.');
-			expect(text).toContain('B...');
+			expect(text).toBe('4/4\n|A7.  B...    |');
 		});
 
 		test('="always" shows dots for all chords', () => {
@@ -69,8 +67,7 @@ describe('renderSong - chords', () => {
 					alignBars: true,
 				})
 			);
-			expect(text).toContain('A7..');
-			expect(text).toContain('B..');
+			expect(text).toBe('4/4\n|A7..   B..   |');
 		});
 	});
 
@@ -84,9 +81,12 @@ describe('renderSong - chords', () => {
 
 		test('="always" shows bar separators', () => {
 			const text = toText(
-				render(song('C G'), { printBarSeparators: 'always' })
+				render(song('C G'), {
+					printBarSeparators: 'always',
+					alignBars: false,
+				})
 			);
-			expect(text).toContain('|');
+			expect(text).toBe('|C  |G  |');
 		});
 
 		test('="grids" shows separators only for non-positioned chord lines', () => {
@@ -99,10 +99,11 @@ describe('renderSong - chords', () => {
 			);
 			const text = toText(render(input, { printBarSeparators: 'grids' }));
 			const lines = text.split('\n');
-			// Non-positioned line should have bar separators
-			expect(lines[3]).toContain('|');
-			// Positioned line should not
+			// Positioned line should not have bar separators
 			expect(lines[1]).not.toContain('|');
+			// Non-positioned line should have bar separators
+			expect(lines[3]).toContain('|D7');
+			expect(lines[3]).toBe('|D7     |%     |A7     |%     |');
 		});
 	});
 
@@ -110,6 +111,6 @@ describe('renderSong - chords', () => {
 		const text = toText(
 			render(song('A7 % % %'), { alignBars: true })
 		);
-		expect(text).toContain('%');
+		expect(text).toBe('|A7     |%     |%     |%     |');
 	});
 });

--- a/packages/chord-mark/tests/integration-public-api/renderSong-filtering.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-filtering.spec.js
@@ -25,29 +25,57 @@ describe('renderSong - filtering (chartType)', () => {
 
 	test('chartType="all" shows chords and lyrics', () => {
 		const text = toText(render(input, { chartType: 'all', alignBars: true }));
-		expect(text).toContain('A7');
-		expect(text).toContain('v1-line-1');
-		expect(text).toContain('v2-line-1');
+		expect(text).toBe(
+			'Verse 1\n' +
+			'|A7     |%      |%      |%      |\n' +
+			'v1-line-1\n' +
+			'|D7     |%      |A7     |%      |\n' +
+			'v1-line-2\n' +
+			'|E7     |D7     |A7     |E7     |\n' +
+			'v1-line-3\n' +
+			'\n' +
+			'Verse 2\n' +
+			'|A7     |%      |%      |%      |\n' +
+			'v2-line-1\n' +
+			'|D7     |%      |A7     |%      |\n' +
+			'v2-line-2\n' +
+			'|E7     |D7     |A7     |E7     |\n' +
+			'v2-line-3\n'
+		);
 	});
 
-	test('chartType="chords" shows only chords', () => {
+	test('chartType="chords" shows only chords and section labels', () => {
 		const text = toText(
 			render(input, { chartType: 'chords', alignBars: true })
 		);
-		expect(text).toContain('A7');
-		expect(text).not.toContain('v1-line-1');
-		expect(text).not.toContain('v2-line-1');
-		// Section labels still shown
-		expect(text).toContain('Verse');
+		expect(text).toBe(
+			'Verse 1\n' +
+			'|A7     |%      |%      |%      |\n' +
+			'|D7     |%      |A7     |%      |\n' +
+			'|E7     |D7     |A7     |E7     |\n' +
+			'\n' +
+			'Verse 2\n' +
+			'|A7     |%      |%      |%      |\n' +
+			'|D7     |%      |A7     |%      |\n' +
+			'|E7     |D7     |A7     |E7     |\n'
+		);
 	});
 
-	test('chartType="lyrics" shows only lyrics', () => {
+	test('chartType="lyrics" shows only lyrics and section labels', () => {
 		const text = toText(
 			render(input, { chartType: 'lyrics', alignBars: true })
 		);
-		expect(text).not.toContain('A7');
-		expect(text).toContain('v1-line-1');
-		expect(text).toContain('v2-line-1');
+		expect(text).toBe(
+			'Verse 1\n' +
+			'v1-line-1\n' +
+			'v1-line-2\n' +
+			'v1-line-3\n' +
+			'\n' +
+			'Verse 2\n' +
+			'v2-line-1\n' +
+			'v2-line-2\n' +
+			'v2-line-3\n'
+		);
 	});
 
 	test('chartType="chordsFirstLyricLine" shows chords and first lyric line per section', () => {
@@ -57,11 +85,18 @@ describe('renderSong - filtering (chartType)', () => {
 				alignBars: true,
 			})
 		);
-		expect(text).toContain('A7');
-		expect(text).toContain('v1-line-1');
-		expect(text).not.toContain('v1-line-2');
-		expect(text).not.toContain('v1-line-3');
-		expect(text).toContain('v2-line-1');
-		expect(text).not.toContain('v2-line-2');
+		expect(text).toBe(
+			'Verse 1\n' +
+			'|A7     |%      |%      |%      |\n' +
+			'v1-line-1\n' +
+			'|D7     |%      |A7     |%      |\n' +
+			'|E7     |D7     |A7     |E7     |\n' +
+			'\n' +
+			'Verse 2\n' +
+			'|A7     |%      |%      |%      |\n' +
+			'v2-line-1\n' +
+			'|D7     |%      |A7     |%      |\n' +
+			'|E7     |D7     |A7     |E7     |\n'
+		);
 	});
 });

--- a/packages/chord-mark/tests/integration-public-api/renderSong-filtering.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-filtering.spec.js
@@ -1,0 +1,67 @@
+import { parseSong, renderSong } from '../../src/chordMark';
+import toText from './helpers/toText';
+import song from './helpers/songInput';
+
+function render(input, options = {}) {
+	return renderSong(parseSong(input), options);
+}
+
+describe('renderSong - filtering (chartType)', () => {
+	const input = song(
+		'#v',
+		'A7 % % %',
+		'v1-line-1',
+		'D7 % A7 %',
+		'v1-line-2',
+		'E7 D7 A7 E7',
+		'v1-line-3',
+		'',
+		'#v',
+		'v2-line-1',
+		'v2-line-2',
+		'v2-line-3',
+		''
+	);
+
+	test('chartType="all" shows chords and lyrics', () => {
+		const text = toText(render(input, { chartType: 'all', alignBars: true }));
+		expect(text).toContain('A7');
+		expect(text).toContain('v1-line-1');
+		expect(text).toContain('v2-line-1');
+	});
+
+	test('chartType="chords" shows only chords', () => {
+		const text = toText(
+			render(input, { chartType: 'chords', alignBars: true })
+		);
+		expect(text).toContain('A7');
+		expect(text).not.toContain('v1-line-1');
+		expect(text).not.toContain('v2-line-1');
+		// Section labels still shown
+		expect(text).toContain('Verse');
+	});
+
+	test('chartType="lyrics" shows only lyrics', () => {
+		const text = toText(
+			render(input, { chartType: 'lyrics', alignBars: true })
+		);
+		expect(text).not.toContain('A7');
+		expect(text).toContain('v1-line-1');
+		expect(text).toContain('v2-line-1');
+	});
+
+	test('chartType="chordsFirstLyricLine" shows chords and first lyric line per section', () => {
+		const text = toText(
+			render(input, {
+				chartType: 'chordsFirstLyricLine',
+				alignBars: true,
+			})
+		);
+		expect(text).toContain('A7');
+		expect(text).toContain('v1-line-1');
+		expect(text).not.toContain('v1-line-2');
+		expect(text).not.toContain('v1-line-3');
+		expect(text).toContain('v2-line-1');
+		expect(text).not.toContain('v2-line-2');
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/renderSong-options.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-options.spec.js
@@ -22,8 +22,7 @@ describe('renderSong - options', () => {
 			const text = toText(
 				render(song('key C', 'C G'), { alignBars: false })
 			);
-			expect(text).toContain('C');
-			expect(text).toContain('G');
+			expect(text).toBe('key: C\n|C  |G  |');
 		});
 
 		test('roman renders roman numerals', () => {
@@ -32,10 +31,9 @@ describe('renderSong - options', () => {
 					symbolType: 'roman',
 				})
 			);
-			expect(text).toContain('I');
-			expect(text).toContain('ii');
-			expect(text).toContain('IV');
-			expect(text).toContain('V');
+			expect(text).toBe(
+				'key: C\n|I     |ii     |IV     |V     |'
+			);
 		});
 
 		test('roman with multiple keys', () => {
@@ -45,10 +43,15 @@ describe('renderSong - options', () => {
 					{ symbolType: 'roman' }
 				)
 			);
-			// First key: C => I, ii, IV, V, vii°
-			expect(text).toContain('vii°');
-			// Second key: G => IV, v, bVII, I
-			expect(text).toContain('♭VII');
+			const lines = text.split('\n');
+			expect(lines[0]).toBe('key: C');
+			expect(lines[1]).toBe(
+				'|I      |ii     |IV       |V     |vii°     |'
+			);
+			expect(lines[2]).toBe('key: G');
+			expect(lines[3]).toBe(
+				'|IV     |v      |♭VII     |I     |?°       |'
+			);
 		});
 	});
 
@@ -63,8 +66,9 @@ describe('renderSong - options', () => {
 				})
 			);
 			const lines = text.split('\n');
-			// Single chord line should have no dots
 			expect(lines[1]).not.toContain('.');
+			expect(lines[2]).not.toContain('.');
+			expect(lines[3]).not.toContain('.');
 		});
 
 		test('="uneven"', () => {
@@ -74,11 +78,13 @@ describe('renderSong - options', () => {
 					alignBars: true,
 				})
 			);
-			// Uneven duration line should show dots
-			expect(text).toContain('A7.');
-			expect(text).toContain('B...');
-			// Even duration line should not show dots
 			const lines = text.split('\n');
+			// Single chord: no dots (nothing is uneven)
+			expect(lines[1]).not.toContain('.');
+			// Uneven durations: dots shown
+			expect(lines[2]).toContain('A7.');
+			expect(lines[2]).toContain('B...');
+			// Even durations: no dots
 			expect(lines[3]).not.toContain('.');
 		});
 
@@ -89,9 +95,12 @@ describe('renderSong - options', () => {
 					alignBars: true,
 				})
 			);
+			const lines = text.split('\n');
+			// Single chord: still no dots (only 1 chord, nothing to show)
+			expect(lines[1]).not.toContain('.');
 			// Even duration line should also show dots
-			expect(text).toContain('A7..');
-			expect(text).toContain('B..');
+			expect(lines[3]).toContain('A7..');
+			expect(lines[3]).toContain('B..');
 		});
 	});
 });

--- a/packages/chord-mark/tests/integration-public-api/renderSong-options.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-options.spec.js
@@ -22,7 +22,10 @@ describe('renderSong - options', () => {
 			const text = toText(
 				render(song('key C', 'C G'), { alignBars: false })
 			);
-			expect(text).toBe('key: C\n|C  |G  |');
+			expect(text).toBe(
+				'key: C\n' +
+				'|C  |G  |'
+			);
 		});
 
 		test('roman renders roman numerals', () => {
@@ -32,7 +35,8 @@ describe('renderSong - options', () => {
 				})
 			);
 			expect(text).toBe(
-				'key: C\n|I     |ii     |IV     |V     |'
+				'key: C\n' +
+				'|I     |ii     |IV     |V     |'
 			);
 		});
 

--- a/packages/chord-mark/tests/integration-public-api/renderSong-options.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-options.spec.js
@@ -1,0 +1,97 @@
+import { parseSong, renderSong } from '../../src/chordMark';
+import toText from './helpers/toText';
+import song from './helpers/songInput';
+
+function render(input, options = {}) {
+	return renderSong(parseSong(input), options);
+}
+
+describe('renderSong - options', () => {
+	describe('chordSymbolRenderer', () => {
+		test('uses custom chord symbol renderer', () => {
+			const chordSymbolRenderer = () => 'Custom';
+			const text = toText(
+				render(song('A B C'), { chordSymbolRenderer })
+			);
+			expect(text).toBe('|Custom     |Custom     |Custom     |');
+		});
+	});
+
+	describe('symbolType', () => {
+		test('chord (default) renders chord names', () => {
+			const text = toText(
+				render(song('key C', 'C G'), { alignBars: false })
+			);
+			expect(text).toContain('C');
+			expect(text).toContain('G');
+		});
+
+		test('roman renders roman numerals', () => {
+			const text = toText(
+				render(song('key C', 'C Dm F G'), {
+					symbolType: 'roman',
+				})
+			);
+			expect(text).toContain('I');
+			expect(text).toContain('ii');
+			expect(text).toContain('IV');
+			expect(text).toContain('V');
+		});
+
+		test('roman with multiple keys', () => {
+			const text = toText(
+				render(
+					song('key C', 'C Dm F G B°', 'key G', 'C Dm F G B°'),
+					{ symbolType: 'roman' }
+				)
+			);
+			// First key: C => I, ii, IV, V, vii°
+			expect(text).toContain('vii°');
+			// Second key: G => IV, v, bVII, I
+			expect(text).toContain('♭VII');
+		});
+	});
+
+	describe('printChordsDuration', () => {
+		const input = song('4/4', 'A7', 'A7. B...', 'A7.. B..');
+
+		test('="never"', () => {
+			const text = toText(
+				render(input, {
+					printChordsDuration: 'never',
+					alignBars: true,
+				})
+			);
+			const lines = text.split('\n');
+			// Single chord line should have no dots
+			expect(lines[1]).not.toContain('.');
+		});
+
+		test('="uneven"', () => {
+			const text = toText(
+				render(input, {
+					printChordsDuration: 'uneven',
+					alignBars: true,
+				})
+			);
+			// Uneven duration line should show dots
+			expect(text).toContain('A7.');
+			expect(text).toContain('B...');
+			// Even duration line should not show dots
+			const lines = text.split('\n');
+			expect(lines[3]).not.toContain('.');
+		});
+
+		test('="always"', () => {
+			const text = toText(
+				render(input, {
+					printChordsDuration: 'always',
+					alignBars: true,
+				})
+			);
+			// Even duration line should also show dots
+			expect(text).toContain('A7..');
+			expect(text).toContain('B..');
+		});
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/renderSong-sections.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-sections.spec.js
@@ -43,12 +43,19 @@ describe('renderSong - sections', () => {
 
 		test('repeated sections get numbered', () => {
 			const text = toText(render(song('#v', '#v', '#v')));
-			expect(text).toBe('Verse 1\nVerse 2\nVerse 3');
+			expect(text).toBe(
+				'Verse 1\n' +
+				'Verse 2\n' +
+				'Verse 3'
+			);
 		});
 
 		test('different section types are not numbered if unique', () => {
 			const text = toText(render(song('#v', '#c')));
-			expect(text).toBe('Verse\nChorus');
+			expect(text).toBe(
+				'Verse\n' +
+				'Chorus'
+			);
 		});
 	});
 
@@ -114,7 +121,12 @@ describe('renderSong - sections', () => {
 			const text = toText(
 				render(input, { expandSectionMultiply: true })
 			);
-			expect(text).toBe('Verse 1\nVerse 2\nVerse 3\nVerse 4');
+			expect(text).toBe(
+				'Verse 1\n' +
+				'Verse 2\n' +
+				'Verse 3\n' +
+				'Verse 4'
+			);
 		});
 	});
 

--- a/packages/chord-mark/tests/integration-public-api/renderSong-sections.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-sections.spec.js
@@ -144,7 +144,7 @@ describe('renderSong - sections', () => {
 				render(input, { autoRepeatChords: true, alignBars: false })
 			);
 			expect(text).toContain('|C  |G  |');
-			expect(text.match(/\|C  \|G  \|/g).length).toBe(2);
+			expect(text.match(/\|C {2}\|G {2}\|/g).length).toBe(2);
 		});
 
 		test('does not repeat chords when false', () => {

--- a/packages/chord-mark/tests/integration-public-api/renderSong-sections.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-sections.spec.js
@@ -1,0 +1,169 @@
+import { parseSong, renderSong } from '../../src/chordMark';
+import toText from './helpers/toText';
+import song from './helpers/songInput';
+
+function render(input, options = {}) {
+	return renderSong(parseSong(input), options);
+}
+
+describe('renderSong - sections', () => {
+	describe('section label rendering', () => {
+		describe.each([
+			['#a', 'Adlib'],
+			['#b', 'Bridge'],
+			['#c', 'Chorus'],
+			['#i', 'Intro'],
+			['#o', 'Outro'],
+			['#p', 'Pre-chorus'],
+			['#s', 'Solo'],
+			['#u', 'Interlude'],
+			['#v', 'Verse'],
+		])('renders %s as %s', (input, expected) => {
+			test(`${input} => ${expected}`, () => {
+				const text = toText(
+					render(song(input), { expandSectionMultiply: true })
+				);
+				expect(text).toBe(expected);
+			});
+		});
+
+		test('renders custom section with capitalized first letter', () => {
+			const text = toText(
+				render(song('#special'), { expandSectionMultiply: true })
+			);
+			expect(text).toBe('Special');
+		});
+	});
+
+	describe('section numbering', () => {
+		test('unique section has no index', () => {
+			const text = toText(render(song('#v')));
+			expect(text).toBe('Verse');
+		});
+
+		test('repeated sections get numbered', () => {
+			const text = toText(render(song('#v', '#v', '#v')));
+			expect(text).toBe('Verse 1\nVerse 2\nVerse 3');
+		});
+
+		test('different section types are not numbered if unique', () => {
+			const text = toText(render(song('#v', '#c')));
+			expect(text).toBe('Verse\nChorus');
+		});
+	});
+
+	describe('expandSectionCopy', () => {
+		test('copies section content when true', () => {
+			const input = song(
+				'#v',
+				'A B',
+				'verseLine',
+				'#v',
+				'#v'
+			);
+			const text = toText(
+				render(input, { expandSectionCopy: true })
+			);
+			expect(text).toContain('Verse 1');
+			expect(text).toContain('Verse 2');
+			expect(text).toContain('Verse 3');
+			// Content appears multiple times
+			expect(text.match(/verseLine/g).length).toBe(3);
+		});
+
+		test('only shows label when false', () => {
+			const input = song(
+				'#v',
+				'A B',
+				'verseLine',
+				'#v',
+				'#v'
+			);
+			const text = toText(
+				render(input, { expandSectionCopy: false })
+			);
+			expect(text).toContain('Verse 1');
+			expect(text).toContain('Verse 2');
+			expect(text).toContain('Verse 3');
+			expect(text.match(/verseLine/g).length).toBe(1);
+		});
+	});
+
+	describe('expandSectionMultiply', () => {
+		test('repeats section when true', () => {
+			const input = song('#v x2', 'A B', 'verseLine1');
+			const text = toText(
+				render(input, { expandSectionMultiply: true })
+			);
+			expect(text).toContain('Verse 1');
+			expect(text).toContain('Verse 2');
+			expect(text.match(/verseLine1/g).length).toBe(2);
+		});
+
+		test('shows repeat string when false', () => {
+			const input = song('#v x2', 'A B', 'verseLine1');
+			const text = toText(
+				render(input, { expandSectionMultiply: false })
+			);
+			expect(text).toContain('Verse x2');
+			expect(text.match(/verseLine1/g).length).toBe(1);
+		});
+
+		test('numbers sections incrementally', () => {
+			const input = song('#v', '#v x2', '#v');
+			const text = toText(
+				render(input, { expandSectionMultiply: true })
+			);
+			expect(text).toBe('Verse 1\nVerse 2\nVerse 3\nVerse 4');
+		});
+	});
+
+	describe('autoRepeatChords', () => {
+		test('repeats chords when true', () => {
+			const input = song(
+				'#v',
+				'C G',
+				'line1',
+				'',
+				'#v',
+				'line2'
+			);
+			const text = toText(
+				render(input, { autoRepeatChords: true, alignBars: false })
+			);
+			expect(text).toContain('|C  |G  |');
+			expect(text.match(/\|C  \|G  \|/g).length).toBe(2);
+		});
+
+		test('does not repeat chords when false', () => {
+			const input = song(
+				'#v',
+				'C G',
+				'line1',
+				'',
+				'#v',
+				'line2'
+			);
+			const text = toText(
+				render(input, { autoRepeatChords: false })
+			);
+			expect(text.match(/\|C/g).length).toBe(1);
+		});
+	});
+
+	describe('section CSS classes', () => {
+		test('wraps sections in divs with CSS classes', () => {
+			const rendered = render(
+				song('#v', 'C G', 'line', '#c', 'F G', 'line')
+			);
+			expect(rendered).toContain('cmSection');
+			expect(rendered).toContain('cmSection-Verse');
+			expect(rendered).toContain('cmSection-Chorus');
+		});
+
+		test('no section wrapper when no sections', () => {
+			const rendered = render(song('C G', 'A line'));
+			expect(rendered).not.toContain('cmSection');
+		});
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/renderSong-sub-beats.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-sub-beats.spec.js
@@ -1,0 +1,63 @@
+import { parseSong, renderSong } from '../../src/chordMark';
+import toText from './helpers/toText';
+import song from './helpers/songInput';
+
+function render(input, options = {}) {
+	return renderSong(parseSong(input), options);
+}
+
+describe('renderSong - sub-beats', () => {
+	const input = song(
+		'C.. G.. Am.. F..',
+		'No woman no cry',
+		'C.. [F C/E] [Dm7 C] C.. G..',
+		'No woman no cry'
+	);
+
+	test('prints sub-beat delimiters by default', () => {
+		const text = toText(render(input));
+		expect(text).toContain('[F C/E]');
+		expect(text).toContain('[Dm7 C]');
+	});
+
+	test('prints sub-beat delimiters when explicitly true', () => {
+		const text = toText(
+			render(input, { printSubBeatDelimiters: true })
+		);
+		expect(text).toContain('[F C/E]');
+		expect(text).toContain('[Dm7 C]');
+	});
+
+	test('hides sub-beat delimiters when false', () => {
+		const text = toText(
+			render(input, { printSubBeatDelimiters: false })
+		);
+		expect(text).not.toContain('[');
+		expect(text).not.toContain(']');
+		expect(text).toContain('F C/E');
+		expect(text).toContain('Dm7 C');
+	});
+
+	test('sub-beats with positioned chords', () => {
+		const input2 = song(
+			'C.. [F C/E] [Dm7 C] C.. G..',
+			'_ No _wo_man _no _cry'
+		);
+		const text = toText(
+			render(input2, { printSubBeatDelimiters: true })
+		);
+		expect(text).toContain('No');
+		expect(text).toContain('cry');
+	});
+
+	test('sub-beats in 3/4 time', () => {
+		const input3 = song('3/4', 'C. [Am G]');
+		const text = toText(
+			render(input3, {
+				printSubBeatDelimiters: true,
+				alignBars: false,
+			})
+		);
+		expect(text).toContain('[Am G]');
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/renderSong-sub-beats.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-sub-beats.spec.js
@@ -46,18 +46,18 @@ describe('renderSong - sub-beats', () => {
 		const text = toText(
 			render(input2, { printSubBeatDelimiters: true })
 		);
-		expect(text).toContain('No');
-		expect(text).toContain('cry');
+		expect(text).toBe(
+			'|C..  [F C/E] [Dm7 C] |C G |\n    No woman   no  cry'
+		);
 	});
 
 	test('sub-beats in 3/4 time', () => {
-		const input3 = song('3/4', 'C. [Am G]');
 		const text = toText(
-			render(input3, {
+			render(song('3/4', 'C. [Am G]'), {
 				printSubBeatDelimiters: true,
 				alignBars: false,
 			})
 		);
-		expect(text).toContain('[Am G]');
+		expect(text).toBe('3/4\nC. [Am G]');
 	});
 });

--- a/packages/chord-mark/tests/integration-public-api/renderSong-sub-beats.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-sub-beats.spec.js
@@ -47,7 +47,8 @@ describe('renderSong - sub-beats', () => {
 			render(input2, { printSubBeatDelimiters: true })
 		);
 		expect(text).toBe(
-			'|C..  [F C/E] [Dm7 C] |C G |\n    No woman   no  cry'
+			'|C..  [F C/E] [Dm7 C] |C G |\n' +
+			'    No woman   no  cry'
 		);
 	});
 
@@ -58,6 +59,9 @@ describe('renderSong - sub-beats', () => {
 				alignBars: false,
 			})
 		);
-		expect(text).toBe('3/4\nC. [Am G]');
+		expect(text).toBe(
+			'3/4\n' +
+			'C. [Am G]'
+		);
 	});
 });

--- a/packages/chord-mark/tests/integration-public-api/renderSong-time-signatures.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-time-signatures.spec.js
@@ -1,0 +1,65 @@
+import { parseSong, renderSong } from '../../src/chordMark';
+import toText from './helpers/toText';
+import song from './helpers/songInput';
+
+function render(input, options = {}) {
+	return renderSong(parseSong(input), options);
+}
+
+describe('renderSong - time signatures', () => {
+	test('renders standalone time signature line', () => {
+		const text = toText(render(song('4/4', 'C')));
+		expect(text).toContain('4/4');
+	});
+
+	test('renders 3/4 time signature', () => {
+		const text = toText(render(song('3/4', 'C. D. E.')));
+		expect(text).toContain('3/4');
+	});
+
+	describe('printInlineTimeSignatures', () => {
+		const input = song(
+			'4/4',
+			'2/4 G 4/4 Am',
+			"_A line _with changes"
+		);
+
+		test('prints inline time signatures by default', () => {
+			const text = toText(render(input));
+			expect(text).toContain('2/4');
+			expect(text).toContain('4/4');
+		});
+
+		test('prints inline time signatures when explicitly true', () => {
+			const text = toText(
+				render(input, { printInlineTimeSignatures: true })
+			);
+			expect(text).toContain('2/4');
+		});
+
+		test('hides inline time signatures when false', () => {
+			const text = toText(
+				render(input, { printInlineTimeSignatures: false })
+			);
+			const lines = text.split('\n');
+			// Chord line should not contain time signatures
+			expect(lines[1]).not.toContain('2/4');
+			expect(lines[1]).not.toContain('4/4');
+		});
+	});
+
+	test('inline time signature different from default', () => {
+		const input = song(
+			'6/8',
+			'Em D. C.',
+			'_ So close no matter _how far _',
+			'3/8 D 6/8 Em %',
+			'_ But I _know'
+		);
+		const text = toText(
+			render(input, { printInlineTimeSignatures: true })
+		);
+		expect(text).toContain('3/8');
+		expect(text).toContain('6/8');
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/renderSong-time-signatures.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-time-signatures.spec.js
@@ -9,12 +9,18 @@ function render(input, options = {}) {
 describe('renderSong - time signatures', () => {
 	test('renders standalone time signature line', () => {
 		const text = toText(render(song('4/4', 'C')));
-		expect(text).toBe('4/4\n|C     |');
+		expect(text).toBe(
+			'4/4\n' +
+			'|C     |'
+		);
 	});
 
 	test('renders 3/4 time signature', () => {
 		const text = toText(render(song('3/4', 'C. D. E.')));
-		expect(text).toBe('3/4\n|C  D  E|');
+		expect(text).toBe(
+			'3/4\n' +
+			'|C  D  E|'
+		);
 	});
 
 	describe('printInlineTimeSignatures', () => {

--- a/packages/chord-mark/tests/integration-public-api/renderSong-time-signatures.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-time-signatures.spec.js
@@ -9,12 +9,12 @@ function render(input, options = {}) {
 describe('renderSong - time signatures', () => {
 	test('renders standalone time signature line', () => {
 		const text = toText(render(song('4/4', 'C')));
-		expect(text).toContain('4/4');
+		expect(text).toBe('4/4\n|C     |');
 	});
 
 	test('renders 3/4 time signature', () => {
 		const text = toText(render(song('3/4', 'C. D. E.')));
-		expect(text).toContain('3/4');
+		expect(text).toBe('3/4\n|C  D  E|');
 	});
 
 	describe('printInlineTimeSignatures', () => {
@@ -26,15 +26,18 @@ describe('renderSong - time signatures', () => {
 
 		test('prints inline time signatures by default', () => {
 			const text = toText(render(input));
-			expect(text).toContain('2/4');
-			expect(text).toContain('4/4');
+			const lines = text.split('\n');
+			expect(lines[1]).toContain('2/4');
+			expect(lines[1]).toContain('4/4');
 		});
 
 		test('prints inline time signatures when explicitly true', () => {
 			const text = toText(
 				render(input, { printInlineTimeSignatures: true })
 			);
-			expect(text).toContain('2/4');
+			const lines = text.split('\n');
+			expect(lines[1]).toContain('2/4 G');
+			expect(lines[1]).toContain('4/4 Am');
 		});
 
 		test('hides inline time signatures when false', () => {
@@ -42,9 +45,10 @@ describe('renderSong - time signatures', () => {
 				render(input, { printInlineTimeSignatures: false })
 			);
 			const lines = text.split('\n');
-			// Chord line should not contain time signatures
 			expect(lines[1]).not.toContain('2/4');
 			expect(lines[1]).not.toContain('4/4');
+			expect(lines[1]).toContain('G');
+			expect(lines[1]).toContain('Am');
 		});
 	});
 
@@ -59,7 +63,12 @@ describe('renderSong - time signatures', () => {
 		const text = toText(
 			render(input, { printInlineTimeSignatures: true })
 		);
-		expect(text).toContain('3/8');
-		expect(text).toContain('6/8');
+		expect(text).toBe(
+			'6/8\n' +
+			'|Em                  |D       C |\n' +
+			'   So close no matter how far\n' +
+			'|3/8 D     |6/8 Em  |% |\n' +
+			'      But I     know'
+		);
 	});
 });

--- a/packages/chord-mark/tests/integration-public-api/renderSong-time-signatures.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-time-signatures.spec.js
@@ -33,8 +33,7 @@ describe('renderSong - time signatures', () => {
 		test('prints inline time signatures by default', () => {
 			const text = toText(render(input));
 			const lines = text.split('\n');
-			expect(lines[1]).toContain('2/4');
-			expect(lines[1]).toContain('4/4');
+			expect(lines[1]).toBe('|2/4 G     |4/4 Am          |');
 		});
 
 		test('prints inline time signatures when explicitly true', () => {
@@ -42,8 +41,7 @@ describe('renderSong - time signatures', () => {
 				render(input, { printInlineTimeSignatures: true })
 			);
 			const lines = text.split('\n');
-			expect(lines[1]).toContain('2/4 G');
-			expect(lines[1]).toContain('4/4 Am');
+			expect(lines[1]).toBe('|2/4 G     |4/4 Am          |');
 		});
 
 		test('hides inline time signatures when false', () => {

--- a/packages/chord-mark/tests/integration-public-api/renderSong-transposition.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-transposition.spec.js
@@ -1,0 +1,164 @@
+import { parseSong, renderSong } from '../../src/chordMark';
+import toText from './helpers/toText';
+import song from './helpers/songInput';
+
+function render(input, options = {}) {
+	return renderSong(parseSong(input), options);
+}
+
+describe('renderSong - transposition', () => {
+	describe('transposeValue', () => {
+		test('transposes up', () => {
+			const text = toText(
+				render(song('C'), {
+					transposeValue: 1,
+					alignBars: false,
+				})
+			);
+			expect(text).toBe('|C#  |');
+		});
+
+		test('transposes down', () => {
+			const text = toText(
+				render(song('C'), {
+					transposeValue: -11,
+					alignBars: false,
+				})
+			);
+			expect(text).toBe('|Db  |');
+		});
+
+		test('avoids theoretical keys (C+3 => Eb)', () => {
+			const text = toText(
+				render(song('C'), {
+					transposeValue: 3,
+					alignBars: false,
+				})
+			);
+			expect(text).toBe('|Eb  |');
+		});
+
+		test('avoids theoretical keys (C+8 => Ab)', () => {
+			const text = toText(
+				render(song('C'), {
+					transposeValue: 8,
+					alignBars: false,
+				})
+			);
+			expect(text).toBe('|Ab  |');
+		});
+	});
+
+	describe('accidentalsType', () => {
+		test('auto uses key-appropriate accidental (flat)', () => {
+			const text = toText(
+				render(song('F F A#'), { alignBars: false })
+			);
+			expect(text).toBe('|F  |%  |Bb  |');
+		});
+
+		test('auto uses key-appropriate accidental (sharp)', () => {
+			const text = toText(
+				render(song('G G Gb'), { alignBars: false })
+			);
+			expect(text).toBe('|G  |%  |F#  |');
+		});
+
+		test('force flat', () => {
+			const text = toText(
+				render(song('G G F#'), {
+					accidentalsType: 'flat',
+					alignBars: false,
+				})
+			);
+			expect(text).toBe('|G  |%  |Gb  |');
+		});
+
+		test('force sharp', () => {
+			const text = toText(
+				render(song('F F Bb'), {
+					accidentalsType: 'sharp',
+					alignBars: false,
+				})
+			);
+			expect(text).toBe('|F  |%  |A#  |');
+		});
+	});
+
+	describe('explicit key + transpose', () => {
+		test('auto accidentals', () => {
+			const input = song(
+				'key Dm',
+				'Dm A# C Dm',
+				'key C#m',
+				'C#m7 G#7 D'
+			);
+			const text = toText(
+				render(input, {
+					accidentalsType: 'auto',
+					transposeValue: -1,
+					alignBars: false,
+				})
+			);
+			expect(text).toContain('key: C#m');
+			expect(text).toContain('|C#m  |A  |B  |C#m  |');
+			expect(text).toContain('key: Cm');
+			expect(text).toContain('|Cm7  |G7  |Db  |');
+		});
+	});
+
+	describe('transpose with sections', () => {
+		test('transposes repeated section chords', () => {
+			const input = song(
+				'key C',
+				'#v',
+				'Dm7 G7 C %',
+				'The first verse is in the key of C',
+				'key G',
+				'#v',
+				'And the second one in the key of G!'
+			);
+			const text = toText(render(input, { alignBars: false }));
+			expect(text).toContain('|Dm7  |G7  |C  |%  |');
+			expect(text).toContain('|Am7  |D7  |G  |%  |');
+		});
+
+		test('transposes repeated chord lines (%%)', () => {
+			const input = song(
+				'key C',
+				'Dm7 G7 C %',
+				'G7 % C %',
+				'key G',
+				'%%',
+				'%'
+			);
+			const text = toText(render(input, { alignBars: false }));
+			expect(text).toContain('|Am7  |D7  |G  |%  |');
+			expect(text).toContain('|D7  |%  |G  |%  |');
+		});
+	});
+
+	describe('force accidental on theoretical keys', () => {
+		test('force sharp on theoretical key', () => {
+			const text = toText(
+				render(song('C'), {
+					transposeValue: 8,
+					accidentalsType: 'sharp',
+					alignBars: false,
+				})
+			);
+			expect(text).toBe('|G#  |');
+		});
+
+		test('force flat on theoretical key', () => {
+			const text = toText(
+				render(song('Cm'), {
+					transposeValue: -11,
+					accidentalsType: 'flat',
+					alignBars: false,
+				})
+			);
+			expect(text).toBe('|Dbm  |');
+		});
+	});
+});

--- a/packages/chord-mark/tests/integration-public-api/renderSong-transposition.spec.js
+++ b/packages/chord-mark/tests/integration-public-api/renderSong-transposition.spec.js
@@ -100,10 +100,12 @@ describe('renderSong - transposition', () => {
 					alignBars: false,
 				})
 			);
-			expect(text).toContain('key: C#m');
-			expect(text).toContain('|C#m  |A  |B  |C#m  |');
-			expect(text).toContain('key: Cm');
-			expect(text).toContain('|Cm7  |G7  |Db  |');
+			expect(text).toBe(
+				'key: C#m\n' +
+				'|C#m  |A  |B  |C#m  |\n' +
+				'key: Cm\n' +
+				'|Cm7  |G7  |Db  |'
+			);
 		});
 	});
 
@@ -119,8 +121,16 @@ describe('renderSong - transposition', () => {
 				'And the second one in the key of G!'
 			);
 			const text = toText(render(input, { alignBars: false }));
-			expect(text).toContain('|Dm7  |G7  |C  |%  |');
-			expect(text).toContain('|Am7  |D7  |G  |%  |');
+			expect(text).toBe(
+				'key: C\n' +
+				'Verse 1\n' +
+				'|Dm7  |G7  |C  |%  |\n' +
+				'The first verse is in the key of C\n' +
+				'key: G\n' +
+				'Verse 2\n' +
+				'|Am7  |D7  |G  |%  |\n' +
+				'And the second one in the key of G!'
+			);
 		});
 
 		test('transposes repeated chord lines (%%)', () => {
@@ -133,8 +143,14 @@ describe('renderSong - transposition', () => {
 				'%'
 			);
 			const text = toText(render(input, { alignBars: false }));
-			expect(text).toContain('|Am7  |D7  |G  |%  |');
-			expect(text).toContain('|D7  |%  |G  |%  |');
+			expect(text).toBe(
+				'key: C\n' +
+				'|Dm7  |G7  |C  |%  |\n' +
+				'|G7  |%  |C  |%  |\n' +
+				'key: G\n' +
+				'|Am7  |D7  |G  |%  |\n' +
+				'|D7  |%  |G  |%  |'
+			);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Add 17 integration test files (204 tests) that test `parseSong`, `renderSong`, and `lineTypes` exclusively through the public API (`src/chordMark.js`)
- Tests organized by concept: basics, chords, time signatures, sections, keys, error recovery, alignment, transposition, filtering, sub-beats, and options
- Shared fixtures strategy with helpers for HTML-to-text conversion and song input building
- No source files modified, 100% coverage maintained

## Test plan
- [x] `npx jest --testPathPattern="integration-public-api" --verbose` — all 204 tests pass
- [x] `npx jest --coverage` — full suite (1507 tests) passes with 100% coverage
- [x] `git diff packages/chord-mark/src/` — no source files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)